### PR TITLE
Add utf-8 encoding when reading files

### DIFF
--- a/convertio/client.py
+++ b/convertio/client.py
@@ -43,7 +43,7 @@ class Client:
         else:
             _options = None
 
-        with open(fp, 'r') as file:
+        with open(fp, 'r', encoding='utf-8') as file:
             data: ConversionPostDict = {
                 'apikey': self.token,
                 'input': 'base64',


### PR DESCRIPTION
When converting html to gif, if we dont set the encoding to utf-8, some characters get buggy